### PR TITLE
Update README to include Zenodo link (GenHuzz)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Fuzz everything! Now let's fuzz chip!
   Paper: [USENIX link](https://www.usenix.org/conference/usenixsecurity25/presentation/bolcskei) · Code: [comsec-group/encarsia](https://github.com/comsec-group/encarsia)
 
 - **GenHuzz: An Efficient Generative Hardware Fuzzer**  
-  Paper: [USENIX link](https://www.usenix.org/system/files/usenixsecurity25-wu-lichao.pdf) · Code:[ zenodo (partially available)_](https://zenodo.org/records/14727632)
+  Paper: [USENIX link](https://www.usenix.org/system/files/usenixsecurity25-wu-lichao.pdf) · Code:[ zenodo (partially available)](https://zenodo.org/records/14727632)
 
 ### CCS
 - **RISCover: Automatic Discovery of User-exploitable Architectural Security Vulnerabilities in Closed-Source RISC-V CPUs**   

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Fuzz everything! Now let's fuzz chip!
   Paper: [USENIX link](https://www.usenix.org/conference/usenixsecurity25/presentation/bolcskei) · Code: [comsec-group/encarsia](https://github.com/comsec-group/encarsia)
 
 - **GenHuzz: An Efficient Generative Hardware Fuzzer**  
-  Paper: [USENIX link](https://www.usenix.org/system/files/usenixsecurity25-wu-lichao.pdf) · Code: _n/a_
+  Paper: [USENIX link](https://www.usenix.org/system/files/usenixsecurity25-wu-lichao.pdf) · Code:[ zenodo (partially available)_](https://zenodo.org/records/14727632)
 
 ### CCS
 - **RISCover: Automatic Discovery of User-exploitable Architectural Security Vulnerabilities in Closed-Source RISC-V CPUs**   


### PR DESCRIPTION
Hi Hao,
Related to #10 
Per your request in the issue, this PR updates README.md by replacing the “N/A” code link with the Zenodo link for GenHuzz, so readers can at least find something. 

Thanks again for this wonderful README.